### PR TITLE
feat(data): mock-data generator voor 3D-tensordata (#9)

### DIFF
--- a/src/temporal_tensor_benchmark/data/__init__.py
+++ b/src/temporal_tensor_benchmark/data/__init__.py
@@ -1,0 +1,18 @@
+"""Data-module: mock-data generatie en trend-injectie."""
+
+from temporal_tensor_benchmark.data.generator import (
+    Dataset,
+    DatasetConfig,
+    generate_dataset,
+    generate_random_tensor,
+)
+from temporal_tensor_benchmark.data.trends import TrendConfig, inject_trends
+
+__all__ = [
+    "Dataset",
+    "DatasetConfig",
+    "TrendConfig",
+    "generate_dataset",
+    "generate_random_tensor",
+    "inject_trends",
+]

--- a/src/temporal_tensor_benchmark/data/generator.py
+++ b/src/temporal_tensor_benchmark/data/generator.py
@@ -1,0 +1,152 @@
+"""Mock-data generator voor 3D-tensordata (subject x tijd x features).
+
+Genereert datasets met de structuur:
+    - numeric: np.ndarray [N_subjects, T_timesteps, F_numeric]
+    - events:  np.ndarray [N_subjects, T_timesteps, F_events]
+    - static:  np.ndarray [N_subjects, F_static]
+    - labels:  np.ndarray [N_subjects]  (0 of 1)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import numpy as np
+
+from temporal_tensor_benchmark.data.trends import TrendConfig, inject_trends
+
+
+@dataclass
+class DatasetConfig:
+    """Configuratie voor het genereren van een dataset."""
+
+    n_subjects: int = 1000
+    n_timesteps: int = 24
+    n_numeric_features: int = 5
+    n_event_types: int = 4
+    n_static_features: int = 3
+    fraud_ratio: float = 0.5
+    seed: int | None = 42
+    trend: TrendConfig | None = None
+
+
+@dataclass
+class Dataset:
+    """Container voor een gegenereerde dataset."""
+
+    numeric: np.ndarray  # (N, T, F_num)
+    events: np.ndarray  # (N, T, F_evt)
+    static: np.ndarray  # (N, F_static)
+    labels: np.ndarray  # (N,)
+    config: DatasetConfig
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def n_subjects(self) -> int:
+        return self.numeric.shape[0]
+
+    @property
+    def n_timesteps(self) -> int:
+        return self.numeric.shape[1]
+
+    @property
+    def tensor_3d(self) -> np.ndarray:
+        """Gecombineerde 3D-tensor: numeric + events → (N, T, F_num + F_evt)."""
+        return np.concatenate([self.numeric, self.events], axis=2)
+
+
+def generate_random_tensor(
+    n_subjects: int = 1000,
+    n_timesteps: int = 24,
+    n_numeric_features: int = 5,
+    n_event_types: int = 4,
+    n_static_features: int = 3,
+    fraud_ratio: float = 0.5,
+    seed: int | None = 42,
+) -> Dataset:
+    """Genereer volledig willekeurige 3D-tensordata zonder trends.
+
+    Parameters
+    ----------
+    n_subjects : int
+        Aantal subjecten (bijv. burgers/bedrijven).
+    n_timesteps : int
+        Aantal tijdstappen per subject.
+    n_numeric_features : int
+        Aantal numerieke features per tijdstap.
+    n_event_types : int
+        Aantal event-typen per tijdstap (binair).
+    n_static_features : int
+        Aantal statische (niet-tijdsgebonden) features.
+    fraud_ratio : float
+        Fractie van subjecten met label 1 (fraude).
+    seed : int | None
+        Random seed voor reproduceerbaarheid.
+
+    Returns
+    -------
+    Dataset
+        Gegenereerde dataset met random data en ~50/50 labels.
+    """
+    rng = np.random.default_rng(seed)
+
+    numeric = rng.standard_normal((n_subjects, n_timesteps, n_numeric_features))
+    events = rng.binomial(1, 0.15, (n_subjects, n_timesteps, n_event_types)).astype(
+        np.float32
+    )
+    static = rng.standard_normal((n_subjects, n_static_features))
+
+    n_fraud = int(n_subjects * fraud_ratio)
+    labels = np.zeros(n_subjects, dtype=np.int64)
+    labels[:n_fraud] = 1
+    rng.shuffle(labels)
+
+    config = DatasetConfig(
+        n_subjects=n_subjects,
+        n_timesteps=n_timesteps,
+        n_numeric_features=n_numeric_features,
+        n_event_types=n_event_types,
+        n_static_features=n_static_features,
+        fraud_ratio=fraud_ratio,
+        seed=seed,
+    )
+
+    return Dataset(
+        numeric=numeric,
+        events=events,
+        static=static,
+        labels=labels,
+        config=config,
+        metadata={"trend_level": 0, "description": "volledig random, geen trends"},
+    )
+
+
+def generate_dataset(config: DatasetConfig) -> Dataset:
+    """Genereer een dataset op basis van een DatasetConfig, inclusief optionele trends.
+
+    Parameters
+    ----------
+    config : DatasetConfig
+        Volledige configuratie inclusief optionele trend.
+
+    Returns
+    -------
+    Dataset
+        Gegenereerde dataset, met trends geïnjecteerd als config.trend is ingesteld.
+    """
+    dataset = generate_random_tensor(
+        n_subjects=config.n_subjects,
+        n_timesteps=config.n_timesteps,
+        n_numeric_features=config.n_numeric_features,
+        n_event_types=config.n_event_types,
+        n_static_features=config.n_static_features,
+        fraud_ratio=config.fraud_ratio,
+        seed=config.seed,
+    )
+    dataset.config = config
+
+    if config.trend is not None:
+        inject_trends(dataset, config.trend)
+
+    return dataset

--- a/src/temporal_tensor_benchmark/data/trends.py
+++ b/src/temporal_tensor_benchmark/data/trends.py
@@ -1,0 +1,236 @@
+"""Trend-injectie voor mock-data: 5 complexiteitsniveaus.
+
+Level 0: Geen trend (random baseline)
+Level 1: Enkele numerieke trend (bijv. lineaire stijging in feature X)
+Level 2: Enkel event-patroon (bijv. herhaald event Y)
+Level 3: Combinatie numeriek + event
+Level 4: Conditioneel patroon (als A én B dan fraude)
+Level 5: Temporeel conditioneel (A gevolgd door B binnen N tijdstappen)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from temporal_tensor_benchmark.data.generator import Dataset
+
+
+@dataclass
+class TrendConfig:
+    """Configuratie voor trend-injectie."""
+
+    level: int  # 0-5
+    params: dict[str, Any] = field(default_factory=dict)
+
+
+def inject_trends(dataset: "Dataset", trend_config: TrendConfig) -> None:
+    """Injecteer trends in de fraude-subjecten van een dataset (in-place).
+
+    Parameters
+    ----------
+    dataset : Dataset
+        De dataset waarin trends worden geïnjecteerd.
+    trend_config : TrendConfig
+        Configuratie met level en parameters.
+    """
+    injectors = {
+        0: _inject_level_0,
+        1: _inject_level_1_numeric_trend,
+        2: _inject_level_2_event_pattern,
+        3: _inject_level_3_combined,
+        4: _inject_level_4_conditional,
+        5: _inject_level_5_temporal_conditional,
+    }
+
+    if trend_config.level not in injectors:
+        raise ValueError(
+            f"Ongeldig trend-level: {trend_config.level}. Kies 0-5."
+        )
+
+    injectors[trend_config.level](dataset, trend_config.params)
+    dataset.metadata["trend_level"] = trend_config.level
+    dataset.metadata["trend_params"] = trend_config.params
+
+
+def _fraud_mask(dataset: "Dataset") -> np.ndarray:
+    """Retourneer boolean mask van fraude-subjecten."""
+    return dataset.labels == 1
+
+
+def _inject_level_0(dataset: "Dataset", params: dict[str, Any]) -> None:
+    """Level 0: geen trend — data blijft random."""
+    dataset.metadata["description"] = "Level 0: geen trend (random baseline)"
+
+
+def _inject_level_1_numeric_trend(
+    dataset: "Dataset", params: dict[str, Any]
+) -> None:
+    """Level 1: lineaire trend in één numerieke feature voor fraude-subjecten.
+
+    Parameters (in params dict):
+        feature_idx (int): Index van de feature. Default: 0.
+        slope (float): Steilheid van de trend per tijdstap. Default: 0.1.
+        noise_std (float): Ruis op de trend. Default: 0.05.
+    """
+    feature_idx = params.get("feature_idx", 0)
+    slope = params.get("slope", 0.1)
+    noise_std = params.get("noise_std", 0.05)
+
+    mask = _fraud_mask(dataset)
+    n_fraud = mask.sum()
+    T = dataset.n_timesteps
+
+    # Lineaire trend: slope * t + ruis
+    rng = np.random.default_rng(params.get("seed", 123))
+    trend = slope * np.arange(T) + rng.normal(0, noise_std, (n_fraud, T))
+
+    dataset.numeric[mask, :, feature_idx] += trend
+
+    dataset.metadata["description"] = (
+        f"Level 1: lineaire trend (slope={slope}) in feature {feature_idx} "
+        f"voor fraude-subjecten"
+    )
+
+
+def _inject_level_2_event_pattern(
+    dataset: "Dataset", params: dict[str, Any]
+) -> None:
+    """Level 2: herhaald event-patroon voor fraude-subjecten.
+
+    Parameters (in params dict):
+        event_idx (int): Index van het event-type. Default: 0.
+        min_occurrences (int): Minimaal aantal events dat wordt geïnjecteerd. Default: 5.
+        window_size (int): Tijdsvenster waarin events worden geplaatst. Default: hele reeks.
+    """
+    event_idx = params.get("event_idx", 0)
+    min_occurrences = params.get("min_occurrences", 5)
+
+    mask = _fraud_mask(dataset)
+    T = dataset.n_timesteps
+    window_size = params.get("window_size", T)
+
+    rng = np.random.default_rng(params.get("seed", 234))
+
+    for i in np.where(mask)[0]:
+        # Kies random tijdstappen binnen het venster
+        event_times = rng.choice(
+            min(window_size, T), size=min_occurrences, replace=False
+        )
+        dataset.events[i, event_times, event_idx] = 1.0
+
+    dataset.metadata["description"] = (
+        f"Level 2: herhaald event {event_idx} (min {min_occurrences}x) "
+        f"in venster van {window_size} tijdstappen voor fraude-subjecten"
+    )
+
+
+def _inject_level_3_combined(
+    dataset: "Dataset", params: dict[str, Any]
+) -> None:
+    """Level 3: combinatie van numerieke trend + event-patroon.
+
+    Parameters (in params dict):
+        numeric_params (dict): Parameters voor level 1. Default: standaard level 1.
+        event_params (dict): Parameters voor level 2. Default: standaard level 2.
+    """
+    numeric_params = params.get("numeric_params", {})
+    event_params = params.get("event_params", {})
+
+    _inject_level_1_numeric_trend(dataset, numeric_params)
+    _inject_level_2_event_pattern(dataset, event_params)
+
+    dataset.metadata["description"] = (
+        "Level 3: combinatie numerieke trend + event-patroon voor fraude-subjecten"
+    )
+
+
+def _inject_level_4_conditional(
+    dataset: "Dataset", params: dict[str, Any]
+) -> None:
+    """Level 4: conditioneel patroon — fraude alleen als conditie A én B waar zijn.
+
+    Parameters (in params dict):
+        feature_a_idx (int): Numerieke feature A. Default: 0.
+        feature_b_idx (int): Numerieke feature B. Default: 1.
+        threshold_a (float): Drempel voor stijging in A. Default: 0.08.
+        threshold_b (float): Drempel voor daling in B. Default: -0.06.
+    """
+    feature_a_idx = params.get("feature_a_idx", 0)
+    feature_b_idx = params.get("feature_b_idx", 1)
+    slope_a = params.get("slope_a", 0.08)
+    slope_b = params.get("slope_b", -0.06)
+    noise_std = params.get("noise_std", 0.05)
+
+    mask = _fraud_mask(dataset)
+    n_fraud = mask.sum()
+    T = dataset.n_timesteps
+
+    rng = np.random.default_rng(params.get("seed", 345))
+
+    # Conditie A: stijgende trend in feature A
+    trend_a = slope_a * np.arange(T) + rng.normal(0, noise_std, (n_fraud, T))
+    dataset.numeric[mask, :, feature_a_idx] += trend_a
+
+    # Conditie B: dalende trend in feature B
+    trend_b = slope_b * np.arange(T) + rng.normal(0, noise_std, (n_fraud, T))
+    dataset.numeric[mask, :, feature_b_idx] += trend_b
+
+    dataset.metadata["description"] = (
+        f"Level 4: conditioneel patroon — stijging feature {feature_a_idx} "
+        f"(slope={slope_a}) EN daling feature {feature_b_idx} (slope={slope_b}) "
+        f"voor fraude-subjecten"
+    )
+
+
+def _inject_level_5_temporal_conditional(
+    dataset: "Dataset", params: dict[str, Any]
+) -> None:
+    """Level 5: temporeel conditioneel — event A gevolgd door event B binnen N stappen.
+
+    Parameters (in params dict):
+        event_a_idx (int): Index van event A. Default: 0.
+        event_b_idx (int): Index van event B. Default: 1.
+        max_gap (int): Maximaal aantal tijdstappen tussen A en B. Default: 3.
+        n_sequences (int): Aantal A→B sequenties per subject. Default: 2.
+        numeric_feature_idx (int): Extra numerieke trend feature. Default: 0.
+        numeric_slope (float): Slope van extra trend. Default: 0.05.
+    """
+    event_a_idx = params.get("event_a_idx", 0)
+    event_b_idx = params.get("event_b_idx", 1)
+    max_gap = params.get("max_gap", 3)
+    n_sequences = params.get("n_sequences", 2)
+    numeric_feature_idx = params.get("numeric_feature_idx", 0)
+    numeric_slope = params.get("numeric_slope", 0.05)
+    noise_std = params.get("noise_std", 0.03)
+
+    mask = _fraud_mask(dataset)
+    T = dataset.n_timesteps
+
+    rng = np.random.default_rng(params.get("seed", 456))
+
+    for i in np.where(mask)[0]:
+        for _ in range(n_sequences):
+            # Kies tijdstap voor event A, met ruimte voor gap + event B
+            t_a = rng.integers(0, max(1, T - max_gap - 1))
+            gap = rng.integers(1, max_gap + 1)
+            t_b = min(t_a + gap, T - 1)
+
+            dataset.events[i, t_a, event_a_idx] = 1.0
+            dataset.events[i, t_b, event_b_idx] = 1.0
+
+    # Voeg ook een subtiele numerieke trend toe
+    n_fraud = mask.sum()
+    trend = numeric_slope * np.arange(T) + rng.normal(
+        0, noise_std, (n_fraud, T)
+    )
+    dataset.numeric[mask, :, numeric_feature_idx] += trend
+
+    dataset.metadata["description"] = (
+        f"Level 5: temporeel conditioneel — event {event_a_idx} gevolgd door "
+        f"event {event_b_idx} binnen {max_gap} stappen ({n_sequences}x per subject) "
+        f"+ subtiele numerieke trend in feature {numeric_feature_idx}"
+    )

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -1,0 +1,100 @@
+"""Tests voor de mock-data generator."""
+
+import numpy as np
+import pytest
+
+from temporal_tensor_benchmark.data.generator import (
+    Dataset,
+    DatasetConfig,
+    generate_dataset,
+    generate_random_tensor,
+)
+from temporal_tensor_benchmark.data.trends import TrendConfig
+
+
+class TestGenerateRandomTensor:
+    """Tests voor generate_random_tensor()."""
+
+    def test_output_shapes(self):
+        ds = generate_random_tensor(
+            n_subjects=100, n_timesteps=12, n_numeric_features=3,
+            n_event_types=2, n_static_features=4,
+        )
+        assert ds.numeric.shape == (100, 12, 3)
+        assert ds.events.shape == (100, 12, 2)
+        assert ds.static.shape == (100, 4)
+        assert ds.labels.shape == (100,)
+
+    def test_label_distributie_50_50(self):
+        ds = generate_random_tensor(n_subjects=1000, fraud_ratio=0.5)
+        assert ds.labels.sum() == 500
+
+    def test_label_distributie_custom(self):
+        ds = generate_random_tensor(n_subjects=100, fraud_ratio=0.3)
+        assert ds.labels.sum() == 30
+
+    def test_events_zijn_binair(self):
+        ds = generate_random_tensor(n_subjects=50, n_timesteps=10, n_event_types=3)
+        unieke_waarden = np.unique(ds.events)
+        assert set(unieke_waarden).issubset({0.0, 1.0})
+
+    def test_reproduceerbaarheid_met_seed(self):
+        ds1 = generate_random_tensor(n_subjects=50, seed=42)
+        ds2 = generate_random_tensor(n_subjects=50, seed=42)
+        np.testing.assert_array_equal(ds1.numeric, ds2.numeric)
+        np.testing.assert_array_equal(ds1.events, ds2.events)
+        np.testing.assert_array_equal(ds1.static, ds2.static)
+
+    def test_andere_seed_geeft_andere_data(self):
+        ds1 = generate_random_tensor(n_subjects=50, seed=42)
+        ds2 = generate_random_tensor(n_subjects=50, seed=99)
+        assert not np.array_equal(ds1.numeric, ds2.numeric)
+
+    def test_tensor_3d_property(self):
+        ds = generate_random_tensor(
+            n_subjects=10, n_timesteps=5,
+            n_numeric_features=3, n_event_types=2,
+        )
+        combined = ds.tensor_3d
+        assert combined.shape == (10, 5, 5)  # 3 + 2
+
+    def test_n_subjects_property(self):
+        ds = generate_random_tensor(n_subjects=77)
+        assert ds.n_subjects == 77
+
+    def test_n_timesteps_property(self):
+        ds = generate_random_tensor(n_timesteps=36)
+        assert ds.n_timesteps == 36
+
+
+class TestGenerateDataset:
+    """Tests voor generate_dataset()."""
+
+    def test_zonder_trend(self):
+        config = DatasetConfig(n_subjects=50, n_timesteps=10)
+        ds = generate_dataset(config)
+        assert ds.numeric.shape == (50, 10, 5)
+        assert ds.config is config
+
+    def test_met_trend_level_1(self):
+        config = DatasetConfig(
+            n_subjects=100,
+            n_timesteps=24,
+            trend=TrendConfig(level=1, params={"slope": 0.2}),
+        )
+        ds = generate_dataset(config)
+        assert ds.metadata["trend_level"] == 1
+
+    def test_met_trend_level_0(self):
+        config = DatasetConfig(
+            n_subjects=50,
+            trend=TrendConfig(level=0),
+        )
+        ds = generate_dataset(config)
+        assert ds.metadata["trend_level"] == 0
+
+    def test_config_wordt_bewaard(self):
+        config = DatasetConfig(n_subjects=30, seed=99)
+        ds = generate_dataset(config)
+        assert ds.config.seed == 99
+        assert ds.config.n_subjects == 30

--- a/tests/test_trends.py
+++ b/tests/test_trends.py
@@ -1,0 +1,238 @@
+"""Tests voor trend-injectie functies."""
+
+import numpy as np
+import pytest
+
+from temporal_tensor_benchmark.data.generator import generate_random_tensor
+from temporal_tensor_benchmark.data.trends import TrendConfig, inject_trends
+
+
+class TestLevel0GeenTrend:
+    """Level 0: geen trend — data blijft random."""
+
+    def test_data_ongewijzigd(self):
+        ds = generate_random_tensor(n_subjects=100, seed=42)
+        numeric_voor = ds.numeric.copy()
+        inject_trends(ds, TrendConfig(level=0))
+        np.testing.assert_array_equal(ds.numeric, numeric_voor)
+
+    def test_metadata_bevat_level(self):
+        ds = generate_random_tensor(n_subjects=50)
+        inject_trends(ds, TrendConfig(level=0))
+        assert ds.metadata["trend_level"] == 0
+
+
+class TestLevel1NumeriekeTrend:
+    """Level 1: lineaire trend in één numerieke feature."""
+
+    def test_fraude_subjecten_hebben_hogere_waarden_aan_einde(self):
+        ds = generate_random_tensor(
+            n_subjects=200, n_timesteps=24, n_numeric_features=3, seed=42
+        )
+        inject_trends(ds, TrendConfig(level=1, params={"feature_idx": 0, "slope": 0.2}))
+
+        fraud_mask = ds.labels == 1
+        # Gemiddelde van feature 0 op laatste tijdstap vs. eerste
+        fraud_begin = ds.numeric[fraud_mask, :3, 0].mean()
+        fraud_einde = ds.numeric[fraud_mask, -3:, 0].mean()
+        assert fraud_einde > fraud_begin
+
+    def test_niet_fraude_subjecten_onveranderd(self):
+        ds1 = generate_random_tensor(n_subjects=100, seed=42)
+        ds2 = generate_random_tensor(n_subjects=100, seed=42)
+        inject_trends(ds1, TrendConfig(level=1, params={"feature_idx": 0}))
+
+        not_fraud = ds1.labels == 0
+        np.testing.assert_array_equal(
+            ds1.numeric[not_fraud], ds2.numeric[not_fraud]
+        )
+
+    def test_andere_features_onveranderd(self):
+        ds1 = generate_random_tensor(
+            n_subjects=100, n_numeric_features=3, seed=42
+        )
+        ds2 = generate_random_tensor(
+            n_subjects=100, n_numeric_features=3, seed=42
+        )
+        inject_trends(ds1, TrendConfig(level=1, params={"feature_idx": 0}))
+
+        fraud = ds1.labels == 1
+        # Feature 1 en 2 moeten ongewijzigd zijn
+        np.testing.assert_array_equal(
+            ds1.numeric[fraud, :, 1:], ds2.numeric[fraud, :, 1:]
+        )
+
+    def test_metadata_beschrijving(self):
+        ds = generate_random_tensor(n_subjects=50)
+        inject_trends(ds, TrendConfig(level=1))
+        assert ds.metadata["trend_level"] == 1
+        assert "Level 1" in ds.metadata["description"]
+
+
+class TestLevel2EventPatroon:
+    """Level 2: herhaald event-patroon voor fraude-subjecten."""
+
+    def test_fraude_heeft_meer_events(self):
+        ds = generate_random_tensor(
+            n_subjects=200, n_timesteps=24, n_event_types=3, seed=42
+        )
+        inject_trends(
+            ds,
+            TrendConfig(level=2, params={"event_idx": 0, "min_occurrences": 8}),
+        )
+
+        fraud = ds.labels == 1
+        not_fraud = ds.labels == 0
+
+        gemiddeld_fraud = ds.events[fraud, :, 0].sum(axis=1).mean()
+        gemiddeld_niet_fraud = ds.events[not_fraud, :, 0].sum(axis=1).mean()
+        assert gemiddeld_fraud > gemiddeld_niet_fraud
+
+    def test_minimaal_aantal_events_geplaatst(self):
+        ds = generate_random_tensor(
+            n_subjects=50, n_timesteps=20, n_event_types=2, seed=42
+        )
+        inject_trends(
+            ds,
+            TrendConfig(level=2, params={"event_idx": 0, "min_occurrences": 6}),
+        )
+        fraud = ds.labels == 1
+        for i in np.where(fraud)[0]:
+            # Minstens 6 events (kan meer zijn door bestaande random events)
+            assert ds.events[i, :, 0].sum() >= 6
+
+    def test_andere_event_types_onveranderd(self):
+        ds1 = generate_random_tensor(
+            n_subjects=100, n_event_types=3, seed=42
+        )
+        ds2 = generate_random_tensor(
+            n_subjects=100, n_event_types=3, seed=42
+        )
+        inject_trends(ds1, TrendConfig(level=2, params={"event_idx": 0}))
+
+        # Event type 1 en 2 moeten ongewijzigd zijn
+        np.testing.assert_array_equal(ds1.events[:, :, 1:], ds2.events[:, :, 1:])
+
+
+class TestLevel3Combinatie:
+    """Level 3: combinatie numeriek + event."""
+
+    def test_beide_patronen_aanwezig(self):
+        ds = generate_random_tensor(
+            n_subjects=200, n_timesteps=24,
+            n_numeric_features=3, n_event_types=3, seed=42,
+        )
+        inject_trends(
+            ds,
+            TrendConfig(
+                level=3,
+                params={
+                    "numeric_params": {"feature_idx": 0, "slope": 0.15},
+                    "event_params": {"event_idx": 1, "min_occurrences": 6},
+                },
+            ),
+        )
+
+        fraud = ds.labels == 1
+        not_fraud = ds.labels == 0
+
+        # Numerieke trend aanwezig
+        fraud_einde = ds.numeric[fraud, -3:, 0].mean()
+        fraud_begin = ds.numeric[fraud, :3, 0].mean()
+        assert fraud_einde > fraud_begin
+
+        # Event-patroon aanwezig
+        events_fraud = ds.events[fraud, :, 1].sum(axis=1).mean()
+        events_niet_fraud = ds.events[not_fraud, :, 1].sum(axis=1).mean()
+        assert events_fraud > events_niet_fraud
+
+
+class TestLevel4Conditioneel:
+    """Level 4: conditioneel — stijging A én daling B."""
+
+    def test_feature_a_stijgt_feature_b_daalt(self):
+        ds = generate_random_tensor(
+            n_subjects=200, n_timesteps=24, n_numeric_features=3, seed=42
+        )
+        inject_trends(
+            ds,
+            TrendConfig(
+                level=4,
+                params={
+                    "feature_a_idx": 0,
+                    "feature_b_idx": 1,
+                    "slope_a": 0.15,
+                    "slope_b": -0.12,
+                },
+            ),
+        )
+
+        fraud = ds.labels == 1
+        # Feature A stijgt
+        a_begin = ds.numeric[fraud, :3, 0].mean()
+        a_einde = ds.numeric[fraud, -3:, 0].mean()
+        assert a_einde > a_begin
+
+        # Feature B daalt
+        b_begin = ds.numeric[fraud, :3, 1].mean()
+        b_einde = ds.numeric[fraud, -3:, 1].mean()
+        assert b_einde < b_begin
+
+
+class TestLevel5TemporalConditional:
+    """Level 5: temporeel conditioneel — event A gevolgd door event B."""
+
+    def test_event_sequenties_aanwezig_bij_fraude(self):
+        ds = generate_random_tensor(
+            n_subjects=200, n_timesteps=24, n_event_types=3, seed=42
+        )
+        inject_trends(
+            ds,
+            TrendConfig(
+                level=5,
+                params={
+                    "event_a_idx": 0,
+                    "event_b_idx": 1,
+                    "max_gap": 3,
+                    "n_sequences": 3,
+                },
+            ),
+        )
+
+        fraud = ds.labels == 1
+        # Fraude-subjecten moeten meer event A en B hebben
+        events_a_fraud = ds.events[fraud, :, 0].sum(axis=1).mean()
+        events_a_niet_fraud = ds.events[~fraud, :, 0].sum(axis=1).mean()
+        assert events_a_fraud > events_a_niet_fraud
+
+    def test_numerieke_trend_ook_aanwezig(self):
+        ds = generate_random_tensor(
+            n_subjects=200, n_timesteps=24, n_numeric_features=3, seed=42
+        )
+        inject_trends(
+            ds,
+            TrendConfig(
+                level=5,
+                params={"numeric_feature_idx": 2, "numeric_slope": 0.1},
+            ),
+        )
+
+        fraud = ds.labels == 1
+        begin = ds.numeric[fraud, :3, 2].mean()
+        einde = ds.numeric[fraud, -3:, 2].mean()
+        assert einde > begin
+
+    def test_metadata_beschrijving(self):
+        ds = generate_random_tensor(n_subjects=50)
+        inject_trends(ds, TrendConfig(level=5))
+        assert ds.metadata["trend_level"] == 5
+        assert "Level 5" in ds.metadata["description"]
+
+
+class TestOngeldigLevel:
+    """Test voor ongeldig trend-level."""
+
+    def test_level_buiten_bereik_geeft_fout(self):
+        ds = generate_random_tensor(n_subjects=10)
+        with pytest.raises(ValueError, match="Ongeldig trend-level"):
+            inject_trends(ds, TrendConfig(level=99))


### PR DESCRIPTION
## Samenvatting

- Mock-data generator voor 3D-tensordata (subject × tijd × features) met `generate_random_tensor()` en `generate_dataset()`
- Trend-injectie met 5 complexiteitsniveaus: van random baseline tot temporeel conditionele patronen
- 28 unit tests die shapes, label-distributie, trend-aanwezigheid en reproduceerbaarheid verifiëren

## Trend-levels

| Level | Beschrijving |
|-------|-------------|
| 0 | Random baseline (geen trend) |
| 1 | Enkele numerieke trend (lineaire stijging) |
| 2 | Event-patroon (herhaalde events) |
| 3 | Combinatie numeriek + event |
| 4 | Conditioneel (stijging A én daling B) |
| 5 | Temporeel conditioneel (event A → B binnen N stappen) |

## Bestanden

- `src/temporal_tensor_benchmark/data/generator.py` — Dataset + DatasetConfig dataclasses, generate functies
- `src/temporal_tensor_benchmark/data/trends.py` — TrendConfig + inject_trends met 5 levels
- `tests/test_generator.py` — 13 tests voor generator
- `tests/test_trends.py` — 15 tests voor trends

## Testplan

- [x] `pytest tests/test_generator.py tests/test_trends.py` — 28/28 passed
- [ ] CI pipeline groen

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)